### PR TITLE
Fix imports for Python 3.10

### DIFF
--- a/r_django_essentials/conf.py
+++ b/r_django_essentials/conf.py
@@ -1,9 +1,10 @@
+from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
+from itertools import chain
+from json import loads as json_loads
 from os import environ
 from os.path import basename, dirname, isfile, join as join_path, splitext
 from sys import stderr
-from collections import Iterable, OrderedDict, defaultdict
-from itertools import chain
-from json import loads as json_loads
 
 from .utils.conf import (
     ensure_app_configs,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='django-essentials',
-    version='1.4.0',
+    version='1.5.0',
     description='Some essential tools when working with any Django project',
     long_description=long_description,
     keywords='django',
@@ -43,18 +43,11 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Framework :: Django',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.2',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
     ],
 
@@ -62,6 +55,6 @@ setup(
     include_package_data = True,
 
     install_requires=[
-        'Django >=1.9.7, <4',
+        'Django >= 3.2, <4',
     ],
 )


### PR DESCRIPTION
# Description

**What?**

Fix importing of ``Iterable``. In Python 3.10 it is imported from ``collections.abc`` and not ``collections``.
Imports are also in alphabetical order now.
Running a-plus unit tests works with Python 3.10 now.

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)
